### PR TITLE
feat: 見出しに左ボーダー+背景色を追加（#7）

### DIFF
--- a/src/components/tiptap/styles/editor.css
+++ b/src/components/tiptap/styles/editor.css
@@ -20,8 +20,11 @@
   font-weight: 700;
   margin-bottom: 8px;
   margin-top: 0;
-  border-bottom: 1px solid #eee;
-  padding-bottom: 4px;
+  border-left: 4px solid #1565c0;
+  background-color: #e3f2fd;
+  padding: 8px 12px;
+  border-radius: 0 4px 4px 0;
+  border-bottom: none;
 }
 
 .ProseMirror h2 {
@@ -29,8 +32,11 @@
   font-weight: 600;
   margin-bottom: 8px;
   margin-top: 16px;
-  border-bottom: 1px solid #eee;
-  padding-bottom: 4px;
+  border-left: 4px solid #2e7d32;
+  background-color: #e8f5e9;
+  padding: 6px 12px;
+  border-radius: 0 4px 4px 0;
+  border-bottom: none;
 }
 
 .ProseMirror h3 {
@@ -38,6 +44,10 @@
   font-weight: 600;
   margin-bottom: 8px;
   margin-top: 12px;
+  border-left: 3px solid #6a1b9a;
+  background-color: #f3e5f5;
+  padding: 4px 12px;
+  border-radius: 0 4px 4px 0;
 }
 
 .ProseMirror p {


### PR DESCRIPTION
## Summary

見出し（H1/H2/H3）に左ボーダー + 背景色を追加し、レベルごとに色で識別できるようにする。

### カラーマッピング

| レベル | 左ボーダー | 背景色 |
|-------|-----------|--------|
| H1 | `#1565c0`（青） | `#e3f2fd` |
| H2 | `#2e7d32`（緑） | `#e8f5e9` |
| H3 | `#6a1b9a`（紫） | `#f3e5f5` |

### 変更内容

- `editor.css` の H1/H2 の `border-bottom` を `border-left` + `background-color` に変更
- H3 にも `border-left` + `background-color` を追加
- 角丸（右側のみ）を適用

## Test plan

- [x] `npm run build` 成功
- [x] `npx vitest run` 全テスト通過
- [ ] ブラウザで H1/H2/H3 の色分け表示を確認

Closes #7
