### PR TITLE
feat: Notion風にエディタ本文を中央寄せ

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -12,11 +12,13 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogActions from "@mui/material/DialogActions";
 import Button from "@mui/material/Button";
+import Switch from "@mui/material/Switch";
 import DownloadIcon from "@mui/icons-material/Download";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import { useEditorInstance } from "@/hooks/useEditorInstance";
 import { useEditorStore, EMPTY_CONTENT } from "@/hooks/useEditorStore";
+import { useEditorPrefs } from "@/hooks/useEditorPrefs";
 
 interface LayoutProps {
   children: ReactNode;
@@ -28,6 +30,8 @@ type Feedback = { message: string; severity: FeedbackSeverity } | null;
 export function Layout({ children }: LayoutProps) {
   const editor = useEditorInstance((s) => s.editor);
   const reset = useEditorStore((s) => s.reset);
+  const centered = useEditorPrefs((s) => s.centered);
+  const toggleCentered = useEditorPrefs((s) => s.toggleCentered);
   const [feedback, setFeedback] = useState<Feedback>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
 
@@ -110,6 +114,15 @@ export function Layout({ children }: LayoutProps) {
             sx={{ height: 20, width: 20, flexGrow: 0, display: "block" }}
           />
           <Box sx={{ flexGrow: 1 }} />
+          <Tooltip title={centered ? "全幅表示に切り替え" : "中央寄せに切り替え"}>
+            <Switch
+              checked={centered}
+              onChange={toggleCentered}
+              size="small"
+              sx={{ mx: 0.5 }}
+              inputProps={{ "aria-label": "toggle centered layout" }}
+            />
+          </Tooltip>
           <Tooltip title="Markdown をコピー">
             <span>
               <IconButton

--- a/src/components/tiptap/TiptapEditor.tsx
+++ b/src/components/tiptap/TiptapEditor.tsx
@@ -15,6 +15,7 @@ import { TaskItem } from "@tiptap/extension-task-item";
 import { Markdown } from "tiptap-markdown";
 import { useEditorStore } from "@/hooks/useEditorStore";
 import { useEditorInstance } from "@/hooks/useEditorInstance";
+import { useEditorPrefs } from "@/hooks/useEditorPrefs";
 import { useFileDrop } from "@/hooks/useFileDrop";
 import { FloatingToolbar } from "./toolbar/FloatingToolbar";
 import { TableMenu } from "./toolbar/TableMenu";
@@ -24,6 +25,7 @@ import "./styles/editor.css";
 
 export function TiptapEditor() {
   const content = useEditorStore((s) => s.content);
+  const centered = useEditorPrefs((s) => s.centered);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const editor = useEditor({
@@ -76,6 +78,7 @@ export function TiptapEditor() {
   return (
     <Box
       ref={containerRef}
+      className={centered ? "editor-centered" : undefined}
       sx={{
         height: "100%",
         overflow: "auto",

--- a/src/components/tiptap/styles/editor.css
+++ b/src/components/tiptap/styles/editor.css
@@ -1,14 +1,17 @@
 .ProseMirror {
   min-height: 100%;
-  max-width: 720px;
   width: 100%;
-  margin: 0 auto;
   padding: 40px 48px;
   box-sizing: border-box;
   outline: none;
   font-size: 1rem;
   line-height: 1.6;
   color: #333;
+}
+
+.editor-centered .ProseMirror {
+  max-width: 720px;
+  margin: 0 auto;
 }
 
 .ProseMirror p.is-editor-empty:first-child::before {

--- a/src/components/tiptap/styles/editor.css
+++ b/src/components/tiptap/styles/editor.css
@@ -1,6 +1,10 @@
 .ProseMirror {
-  height: 100%;
-  padding: 16px 24px;
+  min-height: 100%;
+  max-width: 720px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 40px 48px;
+  box-sizing: border-box;
   outline: none;
   font-size: 1rem;
   line-height: 1.6;

--- a/src/hooks/useEditorPrefs.ts
+++ b/src/hooks/useEditorPrefs.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface EditorPrefsState {
+  centered: boolean;
+  toggleCentered: () => void;
+}
+
+export const useEditorPrefs = create<EditorPrefsState>()(
+  persist(
+    (set) => ({
+      centered: true,
+      toggleCentered: () => set((s) => ({ centered: !s.centered })),
+    }),
+    { name: "markdown-editor-prefs" }
+  )
+);


### PR DESCRIPTION
## 概要

Closes #18

Notion のようにエディタ本文を中央寄せ表示に変更する。

## 変更内容

- `.ProseMirror` に `max-width: 720px` + `margin: 0 auto` を追加
- `height: 100%` → `min-height: 100%` に変更（中央寄せと共存させるため）
- 上下左右の padding を `16px 24px` → `40px 48px` に拡張（Notion 的な余白）
- `box-sizing: border-box` を追加

## Test plan

- [ ] 広い画面でコンテンツが中央に表示される
- [ ] 狭い画面でレスポンシブに追従する
- [ ] スクロールが正常に動作する
- [ ] ビルド・テスト通過（確認済み）