### PR TITLE
ファイルアップロード時の同名ファイル処理を改善する

### DIFF
--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -6,10 +6,11 @@ import {
   waitForElementToBeRemoved,
 } from "@testing-library/react";
 import { act } from "react";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Layout } from "./Layout";
 import { useOpenFiles } from "@/hooks/useOpenFiles";
 import { useSidebarPrefs } from "@/hooks/useSidebarPrefs";
+import { simpleHash } from "@/utils/hash";
 
 vi.mock("@/components/tiptap/TiptapEditor", () => ({
   TiptapEditor: () => <div data-testid="tiptap-editor" />,
@@ -239,5 +240,97 @@ describe("Layout conflict dialog", () => {
       const instances = allFiles.filter((f) => f.name === "a.md");
       expect(instances).toHaveLength(2);
     });
+  });
+});
+
+describe("Layout export filename", () => {
+  let anchorClick: ReturnType<typeof vi.fn>;
+  let createdAnchor: HTMLAnchorElement;
+
+  beforeEach(() => {
+    localStorage.clear();
+    useOpenFiles.setState({ files: [], activeId: null });
+    useSidebarPrefs.setState({ collapsed: true });
+
+    anchorClick = vi.fn();
+    const origCreate = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      if (tag === "a") {
+        createdAnchor = origCreate("a") as HTMLAnchorElement;
+        createdAnchor.click = anchorClick as () => void;
+        return createdAnchor;
+      }
+      return origCreate(tag);
+    });
+
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:mock"),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("uses original filename when content is unchanged", async () => {
+    act(() => {
+      useOpenFiles.setState({
+        files: [
+          {
+            id: "1",
+            name: "note.md",
+            path: "note.md",
+            markdown: "hello",
+            isDirty: false,
+            reloadToken: 0,
+            initialHash: simpleHash("hello"),
+          },
+        ],
+        activeId: "1",
+      });
+    });
+
+    render(
+      <Layout>
+        <div />
+      </Layout>
+    );
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "export markdown" }));
+    });
+
+    expect(createdAnchor.download).toBe("note.md");
+  });
+
+  it("appends _fix when content differs from upload", async () => {
+    act(() => {
+      useOpenFiles.setState({
+        files: [
+          {
+            id: "1",
+            name: "note.md",
+            path: "note.md",
+            markdown: "modified content",
+            isDirty: true,
+            reloadToken: 0,
+            initialHash: simpleHash("original content"),
+          },
+        ],
+        activeId: "1",
+      });
+    });
+
+    render(
+      <Layout>
+        <div />
+      </Layout>
+    );
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "export markdown" }));
+    });
+
+    expect(createdAnchor.download).toBe("note_fix.md");
   });
 });

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -1,4 +1,10 @@
-import { render, screen, fireEvent, waitFor, waitForElementToBeRemoved } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
 import { act } from "react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Layout } from "./Layout";
@@ -149,34 +155,7 @@ describe("Layout conflict dialog", () => {
     expect(file?.markdown).toBe("old");
   });
 
-  it("shows rename dialog when 別名をつける is clicked", async () => {
-    act(() => {
-      useOpenFiles.getState().addFiles([{ name: "a.md", path: "a.md", markdown: "old" }]);
-    });
-
-    const { container } = render(
-      <Layout>
-        <div />
-      </Layout>
-    );
-
-    await act(async () => {
-      dropFiles(container.firstElementChild as HTMLElement, [
-        { name: "a.md", path: "a.md", content: "new" },
-      ]);
-    });
-
-    await screen.findByText("同名ファイルが存在します");
-    act(() => {
-      fireEvent.click(screen.getByRole("button", { name: "別名をつける" }));
-    });
-
-    expect(await screen.findByText("新しいファイル名を入力")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "戻る" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "保存" })).toBeInTheDocument();
-  });
-
-  it("saves file with new name when rename is confirmed", async () => {
+  it("saves file as _v2 automatically when 別名をつける is clicked", async () => {
     act(() => {
       useOpenFiles.getState().addFiles([{ name: "a.md", path: "a.md", markdown: "old" }]);
     });
@@ -198,19 +177,40 @@ describe("Layout conflict dialog", () => {
       fireEvent.click(screen.getByRole("button", { name: "別名をつける" }));
     });
 
-    await screen.findByText("新しいファイル名を入力");
-    const input = screen.getByRole("textbox", { name: "新しいファイル名: a.md" });
+    await waitForElementToBeRemoved(() => screen.queryByText("同名ファイルが存在します"));
+    const original = useOpenFiles.getState().files.find((f) => f.name === "a.md");
+    const renamed = useOpenFiles.getState().files.find((f) => f.name === "a_v2.md");
+    expect(original?.markdown).toBe("old");
+    expect(renamed?.markdown).toBe("new content");
+  });
+
+  it("uses _v3 when _v2 already exists", async () => {
     act(() => {
-      fireEvent.change(input, { target: { value: "renamed.md" } });
-    });
-    act(() => {
-      fireEvent.click(screen.getByRole("button", { name: "保存" }));
+      useOpenFiles.getState().addFiles([
+        { name: "a.md", path: "a.md", markdown: "old" },
+        { name: "a_v2.md", path: "a_v2.md", markdown: "v2" },
+      ]);
     });
 
-    await waitForElementToBeRemoved(() => screen.queryByText("新しいファイル名を入力"));
-    const original = useOpenFiles.getState().files.find((f) => f.name === "a.md");
-    const renamed = useOpenFiles.getState().files.find((f) => f.name === "renamed.md");
-    expect(original?.markdown).toBe("old");
+    const { container } = render(
+      <Layout>
+        <div />
+      </Layout>
+    );
+
+    await act(async () => {
+      dropFiles(container.firstElementChild as HTMLElement, [
+        { name: "a.md", path: "a.md", content: "new content" },
+      ]);
+    });
+
+    await screen.findByText("同名ファイルが存在します");
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "別名をつける" }));
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText("同名ファイルが存在します"));
+    const renamed = useOpenFiles.getState().files.find((f) => f.name === "a_v3.md");
     expect(renamed?.markdown).toBe("new content");
   });
 

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, waitForElementToBeRemoved } from "@testing-library/react";
 import { act } from "react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Layout } from "./Layout";
@@ -39,5 +39,205 @@ describe("Layout header buttons", () => {
     expect(screen.getByRole("button", { name: "copy markdown" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "export markdown" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "close all files" })).toBeEnabled();
+  });
+});
+
+describe("Layout conflict dialog", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useOpenFiles.setState({ files: [], activeId: null });
+    useSidebarPrefs.setState({ collapsed: true });
+  });
+
+  function dropFiles(
+    container: HTMLElement,
+    files: Array<{ name: string; path?: string; content?: string }>
+  ) {
+    const fileObjects = files.map(({ name, path, content = "" }) => {
+      const file = new File([content], name, { type: "text/markdown" });
+      if (path !== undefined) {
+        Object.defineProperty(file, "webkitRelativePath", { value: path });
+      }
+      return file;
+    });
+
+    const dataTransfer = {
+      files: fileObjects,
+      items: fileObjects.map((f) => ({ kind: "file", type: f.type, getAsFile: () => f })),
+      types: ["Files"],
+    };
+
+    fireEvent.dragEnter(container, { dataTransfer });
+    fireEvent.dragOver(container, { dataTransfer });
+    fireEvent.drop(container, { dataTransfer });
+  }
+
+  it("shows 3-button conflict dialog when same-path file is dropped", async () => {
+    act(() => {
+      useOpenFiles.getState().addFiles([{ name: "a.md", path: "a.md", markdown: "old" }]);
+    });
+
+    const { container } = render(
+      <Layout>
+        <div />
+      </Layout>
+    );
+
+    await act(async () => {
+      dropFiles(container.firstElementChild as HTMLElement, [
+        { name: "a.md", path: "a.md", content: "new" },
+      ]);
+    });
+
+    expect(await screen.findByText("同名ファイルが存在します")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "キャンセル" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "別名をつける" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "上書きする" })).toBeInTheDocument();
+  });
+
+  it("overwrites the file when 上書きする is clicked", async () => {
+    act(() => {
+      useOpenFiles.getState().addFiles([{ name: "a.md", path: "a.md", markdown: "old" }]);
+    });
+
+    const { container } = render(
+      <Layout>
+        <div />
+      </Layout>
+    );
+
+    await act(async () => {
+      dropFiles(container.firstElementChild as HTMLElement, [
+        { name: "a.md", path: "a.md", content: "new content" },
+      ]);
+    });
+
+    await screen.findByText("同名ファイルが存在します");
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "上書きする" }));
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText("同名ファイルが存在します"));
+    const updated = useOpenFiles.getState().files.find((f) => f.name === "a.md");
+    expect(updated?.markdown).toBe("new content");
+  });
+
+  it("closes the dialog when キャンセル is clicked", async () => {
+    act(() => {
+      useOpenFiles.getState().addFiles([{ name: "a.md", path: "a.md", markdown: "old" }]);
+    });
+
+    const { container } = render(
+      <Layout>
+        <div />
+      </Layout>
+    );
+
+    await act(async () => {
+      dropFiles(container.firstElementChild as HTMLElement, [
+        { name: "a.md", path: "a.md", content: "new" },
+      ]);
+    });
+
+    await screen.findByText("同名ファイルが存在します");
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText("同名ファイルが存在します"));
+    const file = useOpenFiles.getState().files.find((f) => f.name === "a.md");
+    expect(file?.markdown).toBe("old");
+  });
+
+  it("shows rename dialog when 別名をつける is clicked", async () => {
+    act(() => {
+      useOpenFiles.getState().addFiles([{ name: "a.md", path: "a.md", markdown: "old" }]);
+    });
+
+    const { container } = render(
+      <Layout>
+        <div />
+      </Layout>
+    );
+
+    await act(async () => {
+      dropFiles(container.firstElementChild as HTMLElement, [
+        { name: "a.md", path: "a.md", content: "new" },
+      ]);
+    });
+
+    await screen.findByText("同名ファイルが存在します");
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "別名をつける" }));
+    });
+
+    expect(await screen.findByText("新しいファイル名を入力")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "戻る" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "保存" })).toBeInTheDocument();
+  });
+
+  it("saves file with new name when rename is confirmed", async () => {
+    act(() => {
+      useOpenFiles.getState().addFiles([{ name: "a.md", path: "a.md", markdown: "old" }]);
+    });
+
+    const { container } = render(
+      <Layout>
+        <div />
+      </Layout>
+    );
+
+    await act(async () => {
+      dropFiles(container.firstElementChild as HTMLElement, [
+        { name: "a.md", path: "a.md", content: "new content" },
+      ]);
+    });
+
+    await screen.findByText("同名ファイルが存在します");
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "別名をつける" }));
+    });
+
+    await screen.findByText("新しいファイル名を入力");
+    const input = screen.getByRole("textbox", { name: "新しいファイル名: a.md" });
+    act(() => {
+      fireEvent.change(input, { target: { value: "renamed.md" } });
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "保存" }));
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText("新しいファイル名を入力"));
+    const original = useOpenFiles.getState().files.find((f) => f.name === "a.md");
+    const renamed = useOpenFiles.getState().files.find((f) => f.name === "renamed.md");
+    expect(original?.markdown).toBe("old");
+    expect(renamed?.markdown).toBe("new content");
+  });
+
+  it("adds same-name different-path file without dialog", async () => {
+    act(() => {
+      useOpenFiles
+        .getState()
+        .addFiles([{ name: "a.md", path: "folder1/a.md", markdown: "original" }]);
+    });
+
+    const { container } = render(
+      <Layout>
+        <div />
+      </Layout>
+    );
+
+    await act(async () => {
+      dropFiles(container.firstElementChild as HTMLElement, [
+        { name: "a.md", path: "folder2/a.md", content: "from folder2" },
+      ]);
+    });
+
+    expect(screen.queryByText("同名ファイルが存在します")).not.toBeInTheDocument();
+    await waitFor(() => {
+      const allFiles = useOpenFiles.getState().files;
+      const instances = allFiles.filter((f) => f.name === "a.md");
+      expect(instances).toHaveLength(2);
+    });
   });
 });

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -13,8 +13,6 @@ import DialogContentText from "@mui/material/DialogContentText";
 import DialogActions from "@mui/material/DialogActions";
 import Button from "@mui/material/Button";
 import Switch from "@mui/material/Switch";
-import TextField from "@mui/material/TextField";
-import Typography from "@mui/material/Typography";
 import DownloadIcon from "@mui/icons-material/Download";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
@@ -41,9 +39,6 @@ export function Layout({ children }: LayoutProps) {
   const [feedback, setFeedback] = useState<Feedback>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [pendingConflicts, setPendingConflicts] = useState<IncomingFile[]>([]);
-  const [renameStep, setRenameStep] = useState(false);
-  const [renameValues, setRenameValues] = useState<Record<string, string>>({});
-  const [renameErrors, setRenameErrors] = useState<Record<string, string>>({});
   const dropTargetRef = useRef<HTMLDivElement>(null);
 
   const activeFile = activeId ? files.find((f) => f.id === activeId) : undefined;
@@ -147,55 +142,30 @@ export function Layout({ children }: LayoutProps) {
 
   const cancelOverwrite = () => {
     setPendingConflicts([]);
-    setRenameStep(false);
-    setRenameValues({});
-    setRenameErrors({});
+  };
+
+  const generateAutoName = (baseName: string, existingNames: Set<string>): string => {
+    const dotIdx = baseName.lastIndexOf(".");
+    const base = dotIdx >= 0 ? baseName.slice(0, dotIdx) : baseName;
+    const ext = dotIdx >= 0 ? baseName.slice(dotIdx) : "";
+    const cleanBase = base.replace(/_v\d+$/, "");
+    let version = 2;
+    while (existingNames.has(`${cleanBase}_v${version}${ext}`)) {
+      version++;
+    }
+    return `${cleanBase}_v${version}${ext}`;
   };
 
   const handleRenameClick = () => {
-    const initial: Record<string, string> = {};
-    for (const c of pendingConflicts) {
-      initial[c.name] = c.name;
-    }
-    setRenameValues(initial);
-    setRenameErrors({});
-    setRenameStep(true);
-  };
-
-  const confirmRename = () => {
     const existingNames = new Set(useOpenFiles.getState().files.map((f) => f.name));
-    const newNamesUsed = new Set<string>();
-    const errors: Record<string, string> = {};
-
-    for (const conflict of pendingConflicts) {
-      const newName = renameValues[conflict.name]?.trim() ?? "";
-      if (!newName) {
-        errors[conflict.name] = "ファイル名を入力してください";
-      } else if (existingNames.has(newName)) {
-        errors[conflict.name] = "同名のファイルがすでに開いています";
-      } else if (newNamesUsed.has(newName)) {
-        errors[conflict.name] = "同じ名前が重複しています";
-      } else {
-        newNamesUsed.add(newName);
-      }
-    }
-
-    if (Object.keys(errors).length > 0) {
-      setRenameErrors(errors);
-      return;
-    }
-
-    const renamedFiles: IncomingFile[] = pendingConflicts.map((c) => ({
-      name: renameValues[c.name].trim(),
-      path: renameValues[c.name].trim(),
-      markdown: c.markdown,
-    }));
-
+    const usedNames = new Set(existingNames);
+    const renamedFiles: IncomingFile[] = pendingConflicts.map((c) => {
+      const newName = generateAutoName(c.name, usedNames);
+      usedNames.add(newName);
+      return { name: newName, path: newName, markdown: c.markdown };
+    });
     addFiles(renamedFiles);
     setPendingConflicts([]);
-    setRenameStep(false);
-    setRenameValues({});
-    setRenameErrors({});
   };
 
   const hasFiles = files.length > 0;
@@ -349,10 +319,7 @@ export function Layout({ children }: LayoutProps) {
       </Dialog>
 
       {/* Same-path conflict: overwrite confirmation dialog */}
-      <Dialog
-        open={pendingConflicts.length > 0 && !renameStep}
-        onClose={cancelOverwrite}
-      >
+      <Dialog open={pendingConflicts.length > 0} onClose={cancelOverwrite}>
         <DialogTitle>同名ファイルが存在します</DialogTitle>
         <DialogContent>
           <DialogContentText component="div">
@@ -378,39 +345,6 @@ export function Layout({ children }: LayoutProps) {
           <Button onClick={handleRenameClick}>別名をつける</Button>
           <Button onClick={confirmOverwrite} color="primary" variant="contained">
             上書きする
-          </Button>
-        </DialogActions>
-      </Dialog>
-
-      {/* Rename dialog */}
-      <Dialog open={pendingConflicts.length > 0 && renameStep} onClose={cancelOverwrite}>
-        <DialogTitle>新しいファイル名を入力</DialogTitle>
-        <DialogContent>
-          <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 1 }}>
-            {pendingConflicts.map((c) => (
-              <Box key={c.name}>
-                <Typography variant="body2" sx={{ mb: 0.5, color: "text.secondary" }}>
-                  {c.name}
-                </Typography>
-                <TextField
-                  size="small"
-                  fullWidth
-                  value={renameValues[c.name] ?? c.name}
-                  onChange={(e) =>
-                    setRenameValues((prev) => ({ ...prev, [c.name]: e.target.value }))
-                  }
-                  error={Boolean(renameErrors[c.name])}
-                  helperText={renameErrors[c.name]}
-                  inputProps={{ "aria-label": `新しいファイル名: ${c.name}` }}
-                />
-              </Box>
-            ))}
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setRenameStep(false)}>戻る</Button>
-          <Button onClick={confirmRename} color="primary" variant="contained">
-            保存
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -13,6 +13,8 @@ import DialogContentText from "@mui/material/DialogContentText";
 import DialogActions from "@mui/material/DialogActions";
 import Button from "@mui/material/Button";
 import Switch from "@mui/material/Switch";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
 import DownloadIcon from "@mui/icons-material/Download";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
@@ -39,6 +41,9 @@ export function Layout({ children }: LayoutProps) {
   const [feedback, setFeedback] = useState<Feedback>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [pendingConflicts, setPendingConflicts] = useState<IncomingFile[]>([]);
+  const [renameStep, setRenameStep] = useState(false);
+  const [renameValues, setRenameValues] = useState<Record<string, string>>({});
+  const [renameErrors, setRenameErrors] = useState<Record<string, string>>({});
   const dropTargetRef = useRef<HTMLDivElement>(null);
 
   const activeFile = activeId ? files.find((f) => f.id === activeId) : undefined;
@@ -84,21 +89,41 @@ export function Layout({ children }: LayoutProps) {
 
   const handleDropMarkdown = useCallback(
     (dropped: DroppedFile[]) => {
-      const existingNames = new Set(useOpenFiles.getState().files.map((f) => f.name));
-      const seen = new Set<string>();
-      const conflicts: IncomingFile[] = [];
+      const existingFiles = useOpenFiles.getState().files;
+      const seenPaths = new Set<string>();
+      const samePathConflicts: IncomingFile[] = [];
       const fresh: IncomingFile[] = [];
+      const diffPathSameNames: string[] = [];
+
       for (const file of dropped) {
-        if (existingNames.has(file.name) || seen.has(file.name)) {
-          conflicts.push(file);
+        const filePath = file.path;
+        const samePathExisting = existingFiles.find(
+          (f) => f.name === file.name && (f.path ?? f.name) === filePath
+        );
+
+        if (samePathExisting || seenPaths.has(filePath)) {
+          samePathConflicts.push(file);
         } else {
+          const diffPathExists = existingFiles.some(
+            (f) => f.name === file.name && (f.path ?? f.name) !== filePath
+          );
           fresh.push(file);
-          seen.add(file.name);
+          seenPaths.add(filePath);
+          if (diffPathExists) {
+            diffPathSameNames.push(file.name);
+          }
         }
       }
+
       if (fresh.length > 0) addFiles(fresh);
-      if (conflicts.length > 0) {
-        setPendingConflicts((prev) => mergeByName(prev, conflicts));
+      if (samePathConflicts.length > 0) {
+        setPendingConflicts((prev) => mergeByPath(prev, samePathConflicts));
+      }
+      if (diffPathSameNames.length > 0) {
+        setFeedback({
+          message: "同名のファイルが他の場所にも存在します",
+          severity: "info",
+        });
       }
     },
     [addFiles]
@@ -119,7 +144,59 @@ export function Layout({ children }: LayoutProps) {
     overwriteFiles(pendingConflicts);
     setPendingConflicts([]);
   };
-  const cancelOverwrite = () => setPendingConflicts([]);
+
+  const cancelOverwrite = () => {
+    setPendingConflicts([]);
+    setRenameStep(false);
+    setRenameValues({});
+    setRenameErrors({});
+  };
+
+  const handleRenameClick = () => {
+    const initial: Record<string, string> = {};
+    for (const c of pendingConflicts) {
+      initial[c.name] = c.name;
+    }
+    setRenameValues(initial);
+    setRenameErrors({});
+    setRenameStep(true);
+  };
+
+  const confirmRename = () => {
+    const existingNames = new Set(useOpenFiles.getState().files.map((f) => f.name));
+    const newNamesUsed = new Set<string>();
+    const errors: Record<string, string> = {};
+
+    for (const conflict of pendingConflicts) {
+      const newName = renameValues[conflict.name]?.trim() ?? "";
+      if (!newName) {
+        errors[conflict.name] = "ファイル名を入力してください";
+      } else if (existingNames.has(newName)) {
+        errors[conflict.name] = "同名のファイルがすでに開いています";
+      } else if (newNamesUsed.has(newName)) {
+        errors[conflict.name] = "同じ名前が重複しています";
+      } else {
+        newNamesUsed.add(newName);
+      }
+    }
+
+    if (Object.keys(errors).length > 0) {
+      setRenameErrors(errors);
+      return;
+    }
+
+    const renamedFiles: IncomingFile[] = pendingConflicts.map((c) => ({
+      name: renameValues[c.name].trim(),
+      path: renameValues[c.name].trim(),
+      markdown: c.markdown,
+    }));
+
+    addFiles(renamedFiles);
+    setPendingConflicts([]);
+    setRenameStep(false);
+    setRenameValues({});
+    setRenameErrors({});
+  };
 
   const hasFiles = files.length > 0;
 
@@ -255,6 +332,7 @@ export function Layout({ children }: LayoutProps) {
         )}
       </Box>
 
+      {/* Close all confirmation dialog */}
       <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
         <DialogTitle>すべて閉じる</DialogTitle>
         <DialogContent>
@@ -270,11 +348,15 @@ export function Layout({ children }: LayoutProps) {
         </DialogActions>
       </Dialog>
 
-      <Dialog open={pendingConflicts.length > 0} onClose={cancelOverwrite}>
-        <DialogTitle>同一ファイルがあります</DialogTitle>
+      {/* Same-path conflict: overwrite confirmation dialog */}
+      <Dialog
+        open={pendingConflicts.length > 0 && !renameStep}
+        onClose={cancelOverwrite}
+      >
+        <DialogTitle>同名ファイルが存在します</DialogTitle>
         <DialogContent>
           <DialogContentText component="div">
-            以下のファイルはすでに開いています。上書きしますか？
+            以下のファイルはすでに開いています。
             <Box
               component="ul"
               sx={{
@@ -293,8 +375,42 @@ export function Layout({ children }: LayoutProps) {
         </DialogContent>
         <DialogActions>
           <Button onClick={cancelOverwrite}>キャンセル</Button>
+          <Button onClick={handleRenameClick}>別名をつける</Button>
           <Button onClick={confirmOverwrite} color="primary" variant="contained">
-            上書き
+            上書きする
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Rename dialog */}
+      <Dialog open={pendingConflicts.length > 0 && renameStep} onClose={cancelOverwrite}>
+        <DialogTitle>新しいファイル名を入力</DialogTitle>
+        <DialogContent>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 1 }}>
+            {pendingConflicts.map((c) => (
+              <Box key={c.name}>
+                <Typography variant="body2" sx={{ mb: 0.5, color: "text.secondary" }}>
+                  {c.name}
+                </Typography>
+                <TextField
+                  size="small"
+                  fullWidth
+                  value={renameValues[c.name] ?? c.name}
+                  onChange={(e) =>
+                    setRenameValues((prev) => ({ ...prev, [c.name]: e.target.value }))
+                  }
+                  error={Boolean(renameErrors[c.name])}
+                  helperText={renameErrors[c.name]}
+                  inputProps={{ "aria-label": `新しいファイル名: ${c.name}` }}
+                />
+              </Box>
+            ))}
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setRenameStep(false)}>戻る</Button>
+          <Button onClick={confirmRename} color="primary" variant="contained">
+            保存
           </Button>
         </DialogActions>
       </Dialog>
@@ -320,10 +436,10 @@ export function Layout({ children }: LayoutProps) {
   );
 }
 
-function mergeByName(prev: IncomingFile[], next: IncomingFile[]): IncomingFile[] {
+function mergeByPath(prev: IncomingFile[], next: IncomingFile[]): IncomingFile[] {
   const map = new Map<string, IncomingFile>();
-  for (const item of prev) map.set(item.name, item);
-  for (const item of next) map.set(item.name, item);
+  for (const item of prev) map.set(item.path ?? item.name, item);
+  for (const item of next) map.set(item.path ?? item.name, item);
   return Array.from(map.values());
 }
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -19,6 +19,7 @@ import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import { useOpenFiles, type IncomingFile } from "@/hooks/useOpenFiles";
 import { useEditorPrefs } from "@/hooks/useEditorPrefs";
 import { useFileDrop, type DroppedFile } from "@/hooks/useFileDrop";
+import { simpleHash, buildFixFilename } from "@/utils/hash";
 import { Sidebar } from "./Sidebar";
 
 interface LayoutProps {
@@ -55,7 +56,9 @@ export function Layout({ children }: LayoutProps) {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = activeFile.name || buildFilename();
+    const isModified = simpleHash(activeFile.markdown) !== activeFile.initialHash;
+    const baseName = activeFile.name || buildFilename();
+    a.download = isModified ? buildFixFilename(baseName) : baseName;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);

--- a/src/hooks/useFileDrop.ts
+++ b/src/hooks/useFileDrop.ts
@@ -25,6 +25,7 @@ function readAsText(file: File): Promise<string> {
 
 export interface DroppedFile {
   name: string;
+  path: string;
   markdown: string;
 }
 
@@ -93,6 +94,7 @@ export function useFileDrop({
         const results = await Promise.all(
           markdownFiles.map(async (file) => ({
             name: file.name,
+            path: file.webkitRelativePath || file.name,
             markdown: await readAsText(file),
           }))
         );

--- a/src/hooks/useOpenFiles.ts
+++ b/src/hooks/useOpenFiles.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist, createJSONStorage, type StateStorage } from "zustand/middleware";
+import { simpleHash } from "@/utils/hash";
 
 export interface OpenFile {
   id: string;
@@ -8,6 +9,7 @@ export interface OpenFile {
   markdown: string;
   isDirty: boolean;
   reloadToken: number;
+  initialHash: string;
 }
 
 export interface IncomingFile {
@@ -56,6 +58,7 @@ function buildUntitledFile(existing: Set<string>): OpenFile {
     markdown: "",
     isDirty: false,
     reloadToken: 0,
+    initialHash: simpleHash(""),
   };
 }
 
@@ -101,6 +104,7 @@ export const useOpenFiles = create<OpenFilesState>()(
             markdown: item.markdown,
             isDirty: false,
             reloadToken: 0,
+            initialHash: simpleHash(item.markdown),
           }));
           const files = [...state.files, ...created];
           const activeId = state.activeId ?? created[0].id;
@@ -187,7 +191,10 @@ export const useOpenFiles = create<OpenFilesState>()(
           state.activeId = fresh.id;
           return;
         }
-        state.files = state.files.map((f) => (f.path ? f : { ...f, path: f.name }));
+        state.files = state.files.map((f) => ({
+          ...(f.path ? f : { ...f, path: f.name }),
+          initialHash: f.initialHash ?? simpleHash(f.markdown),
+        }));
         if (!state.activeId || !state.files.some((f) => f.id === state.activeId)) {
           state.activeId = state.files[0].id;
         }

--- a/src/hooks/useOpenFiles.ts
+++ b/src/hooks/useOpenFiles.ts
@@ -4,6 +4,7 @@ import { persist, createJSONStorage, type StateStorage } from "zustand/middlewar
 export interface OpenFile {
   id: string;
   name: string;
+  path: string;
   markdown: string;
   isDirty: boolean;
   reloadToken: number;
@@ -11,6 +12,7 @@ export interface OpenFile {
 
 export interface IncomingFile {
   name: string;
+  path?: string;
   markdown: string;
 }
 
@@ -46,9 +48,11 @@ function nextUntitledName(existing: Set<string>): string {
 }
 
 function buildUntitledFile(existing: Set<string>): OpenFile {
+  const name = nextUntitledName(existing);
   return {
     id: generateId(),
-    name: nextUntitledName(existing),
+    name,
+    path: name,
     markdown: "",
     isDirty: false,
     reloadToken: 0,
@@ -93,6 +97,7 @@ export const useOpenFiles = create<OpenFilesState>()(
           const created: OpenFile[] = incoming.map((item) => ({
             id: generateId(),
             name: item.name,
+            path: item.path ?? item.name,
             markdown: item.markdown,
             isDirty: false,
             reloadToken: 0,
@@ -182,6 +187,7 @@ export const useOpenFiles = create<OpenFilesState>()(
           state.activeId = fresh.id;
           return;
         }
+        state.files = state.files.map((f) => (f.path ? f : { ...f, path: f.name }));
         if (!state.activeId || !state.files.some((f) => f.id === state.activeId)) {
           state.activeId = state.files[0].id;
         }

--- a/src/utils/hash.test.ts
+++ b/src/utils/hash.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { simpleHash, buildFixFilename } from "./hash";
+
+describe("simpleHash", () => {
+  it("returns the same hash for identical strings", () => {
+    expect(simpleHash("hello")).toBe(simpleHash("hello"));
+  });
+
+  it("returns different hashes for different strings", () => {
+    expect(simpleHash("hello")).not.toBe(simpleHash("world"));
+  });
+
+  it("handles empty string", () => {
+    expect(simpleHash("")).toBe(simpleHash(""));
+  });
+});
+
+describe("buildFixFilename", () => {
+  it("appends _fix before extension", () => {
+    expect(buildFixFilename("document.md")).toBe("document_fix.md");
+  });
+
+  it("handles files with no extension", () => {
+    expect(buildFixFilename("README")).toBe("README_fix");
+  });
+
+  it("handles dotfiles (leading dot counts as no extension)", () => {
+    expect(buildFixFilename(".env")).toBe(".env_fix");
+  });
+
+  it("handles multiple dots correctly", () => {
+    expect(buildFixFilename("my.notes.md")).toBe("my.notes_fix.md");
+  });
+});

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,16 @@
+/** djb2 hash — fast, synchronous, good enough for change-detection. */
+export function simpleHash(str: string): string {
+  let h = 5381;
+  for (let i = 0; i < str.length; i++) {
+    h = ((h << 5) + h) ^ str.charCodeAt(i);
+    h = h >>> 0; // keep unsigned 32-bit
+  }
+  return h.toString(36);
+}
+
+/** foo.md → foo_fix.md, foo → foo_fix */
+export function buildFixFilename(name: string): string {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) return `${name}_fix`;
+  return `${name.slice(0, dot)}_fix${name.slice(dot)}`;
+}


### PR DESCRIPTION
## Summary

- 同一パス・同名ファイルをドロップした際、「上書きする」「別名をつける」「キャンセル」の3択ダイアログを表示するよう変更
- 「別名をつける」選択時は新ファイル名入力ダイアログを表示し、バリデーション（空・重複チェック）付きで保存
- 同名・別パスのファイルはサイレント追加し、「同名のファイルが他の場所にも存在します」トーストで通知
- `DroppedFile` / `OpenFile` / `IncomingFile` に `path` フィールドを追加し内部パス比較を実現（`webkitRelativePath || name`）
- localStorage に永続化された既存ファイルとの後方互換性を `onRehydrateStorage` でマイグレーション

## Test plan

- [ ] `Layout conflict dialog` テストが全件パスすること（6件追加）
- [ ] 既存の全テスト（31件）がパスすること
- [ ] 同名ファイルを同じ場所からドロップ → 3択ダイアログが表示されること
- [ ] 「上書きする」でファイルの内容が更新されること
- [ ] 「別名をつける」で新しいファイル名が入力でき、別ファイルとして追加されること
- [ ] 「キャンセル」でダイアログが閉じ、ファイルは変更されないこと
- [ ] 別パスの同名ファイルはダイアログなしで追加され、トースト通知が表示されること

Closes #26