### PR TITLE
feat: 同名ファイルアップロード時に既存ファイルを選択状態にしてエディタを冒頭へスクロール

### DIFF
--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -1,12 +1,23 @@
-import { render, screen } from "@testing-library/react";
-import { act } from "react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Layout } from "./Layout";
 import { useOpenFiles } from "@/hooks/useOpenFiles";
+import { useEditorInstance } from "@/hooks/useEditorInstance";
 import { useSidebarPrefs } from "@/hooks/useSidebarPrefs";
+import type { DroppedFile } from "@/hooks/useFileDrop";
 
 vi.mock("@/components/tiptap/TiptapEditor", () => ({
   TiptapEditor: () => <div data-testid="tiptap-editor" />,
+}));
+
+let capturedOnDropMarkdown: ((files: DroppedFile[]) => void) | null = null;
+
+vi.mock("@/hooks/useFileDrop", () => ({
+  useFileDrop: vi.fn(({ onDropMarkdown }: { onDropMarkdown: (files: DroppedFile[]) => void }) => {
+    capturedOnDropMarkdown = onDropMarkdown;
+    return { isDragging: false };
+  }),
 }));
 
 describe("Layout header buttons", () => {
@@ -14,6 +25,7 @@ describe("Layout header buttons", () => {
     localStorage.clear();
     useOpenFiles.setState({ files: [], activeId: null });
     useSidebarPrefs.setState({ collapsed: true });
+    capturedOnDropMarkdown = null;
   });
 
   it("disables copy/download/close-all when no file is open", () => {
@@ -39,5 +51,107 @@ describe("Layout header buttons", () => {
     expect(screen.getByRole("button", { name: "copy markdown" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "export markdown" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "close all files" })).toBeEnabled();
+  });
+});
+
+describe("Layout overwrite dialog", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useOpenFiles.setState({ files: [], activeId: null });
+    useEditorInstance.setState({ editor: null, scrollToTopToken: 0 });
+    useSidebarPrefs.setState({ collapsed: true });
+    capturedOnDropMarkdown = null;
+  });
+
+  it("shows overwrite dialog when a dropped file conflicts with an existing one", async () => {
+    useOpenFiles.getState().addFiles([{ name: "report.md", markdown: "# Old" }]);
+    render(
+      <Layout>
+        <div />
+      </Layout>
+    );
+
+    act(() => {
+      capturedOnDropMarkdown?.([{ name: "report.md", markdown: "# New" }]);
+    });
+
+    expect(await screen.findByText("同一ファイルがあります")).toBeInTheDocument();
+    expect(screen.getByText("report.md")).toBeInTheDocument();
+  });
+
+  it("confirming overwrite activates the overwritten file", async () => {
+    const user = userEvent.setup();
+    useOpenFiles.getState().addFiles([
+      { name: "a.md", markdown: "# A" },
+      { name: "report.md", markdown: "# Old" },
+    ]);
+    const reportId = useOpenFiles.getState().files.find((f) => f.name === "report.md")!.id;
+    useOpenFiles.getState().setActive(
+      useOpenFiles.getState().files.find((f) => f.name === "a.md")!.id
+    );
+
+    render(
+      <Layout>
+        <div />
+      </Layout>
+    );
+
+    act(() => {
+      capturedOnDropMarkdown?.([{ name: "report.md", markdown: "# New" }]);
+    });
+
+    await screen.findByText("同一ファイルがあります");
+    await user.click(screen.getByRole("button", { name: "上書き" }));
+
+    expect(useOpenFiles.getState().activeId).toBe(reportId);
+  });
+
+  it("confirming overwrite requests scroll to top", async () => {
+    const user = userEvent.setup();
+    useOpenFiles.getState().addFiles([{ name: "report.md", markdown: "# Old" }]);
+
+    render(
+      <Layout>
+        <div />
+      </Layout>
+    );
+
+    act(() => {
+      capturedOnDropMarkdown?.([{ name: "report.md", markdown: "# New" }]);
+    });
+
+    await screen.findByText("同一ファイルがあります");
+
+    const tokenBefore = useEditorInstance.getState().scrollToTopToken;
+    await user.click(screen.getByRole("button", { name: "上書き" }));
+
+    expect(useEditorInstance.getState().scrollToTopToken).toBe(tokenBefore + 1);
+  });
+
+  it("cancelling overwrite does not change active file or scroll", async () => {
+    const user = userEvent.setup();
+    useOpenFiles.getState().addFiles([
+      { name: "a.md", markdown: "# A" },
+      { name: "report.md", markdown: "# Old" },
+    ]);
+    const aId = useOpenFiles.getState().files.find((f) => f.name === "a.md")!.id;
+    useOpenFiles.getState().setActive(aId);
+
+    render(
+      <Layout>
+        <div />
+      </Layout>
+    );
+
+    act(() => {
+      capturedOnDropMarkdown?.([{ name: "report.md", markdown: "# New" }]);
+    });
+
+    await screen.findByText("同一ファイルがあります");
+    const tokenBefore = useEditorInstance.getState().scrollToTopToken;
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    expect(useOpenFiles.getState().activeId).toBe(aId);
+    expect(useEditorInstance.getState().scrollToTopToken).toBe(tokenBefore);
   });
 });

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -132,6 +132,37 @@ describe("Layout overwrite dialog", () => {
     expect(useEditorInstance.getState().scrollToTopToken).toBe(tokenBefore + 1);
   });
 
+  it("dropping a new file activates it", () => {
+    render(
+      <Layout>
+        <div />
+      </Layout>
+    );
+
+    act(() => {
+      capturedOnDropMarkdown?.([{ name: "new.md", markdown: "# New" }]);
+    });
+
+    const newId = useOpenFiles.getState().files.find((f) => f.name === "new.md")!.id;
+    expect(useOpenFiles.getState().activeId).toBe(newId);
+  });
+
+  it("dropping a new file requests scroll to top", () => {
+    render(
+      <Layout>
+        <div />
+      </Layout>
+    );
+
+    const tokenBefore = useEditorInstance.getState().scrollToTopToken;
+
+    act(() => {
+      capturedOnDropMarkdown?.([{ name: "new.md", markdown: "# New" }]);
+    });
+
+    expect(useEditorInstance.getState().scrollToTopToken).toBe(tokenBefore + 1);
+  });
+
   it("cancelling overwrite does not change active file or scroll", async () => {
     const user = userEvent.setup();
     useOpenFiles.getState().addFiles([

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -14,10 +14,12 @@ vi.mock("@/components/tiptap/TiptapEditor", () => ({
 let capturedOnDropMarkdown: ((files: DroppedFile[]) => void) | null = null;
 
 vi.mock("@/hooks/useFileDrop", () => ({
-  useFileDrop: vi.fn(({ onDropMarkdown }: { onDropMarkdown: (files: DroppedFile[]) => void }) => {
-    capturedOnDropMarkdown = onDropMarkdown;
-    return { isDragging: false };
-  }),
+  useFileDrop: vi.fn(
+    ({ onDropMarkdown }: { onDropMarkdown: (files: DroppedFile[]) => void }) => {
+      capturedOnDropMarkdown = onDropMarkdown;
+      return { isDragging: false };
+    }
+  ),
 }));
 
 describe("Layout header buttons", () => {
@@ -85,10 +87,12 @@ describe("Layout overwrite dialog", () => {
       { name: "a.md", markdown: "# A" },
       { name: "report.md", markdown: "# Old" },
     ]);
-    const reportId = useOpenFiles.getState().files.find((f) => f.name === "report.md")!.id;
-    useOpenFiles.getState().setActive(
-      useOpenFiles.getState().files.find((f) => f.name === "a.md")!.id
-    );
+    const reportId = useOpenFiles
+      .getState()
+      .files.find((f) => f.name === "report.md")!.id;
+    useOpenFiles
+      .getState()
+      .setActive(useOpenFiles.getState().files.find((f) => f.name === "a.md")!.id);
 
     render(
       <Layout>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -98,12 +98,15 @@ export function Layout({ children }: LayoutProps) {
           seen.add(file.name);
         }
       }
-      if (fresh.length > 0) addFiles(fresh);
+      if (fresh.length > 0) {
+        addFiles(fresh);
+        requestScrollToTop();
+      }
       if (conflicts.length > 0) {
         setPendingConflicts((prev) => mergeByName(prev, conflicts));
       }
     },
-    [addFiles]
+    [addFiles, requestScrollToTop]
   );
 
   const handleDropError = useCallback(

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -17,6 +17,7 @@ import DownloadIcon from "@mui/icons-material/Download";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import { useOpenFiles, type IncomingFile } from "@/hooks/useOpenFiles";
+import { useEditorInstance } from "@/hooks/useEditorInstance";
 import { useEditorPrefs } from "@/hooks/useEditorPrefs";
 import { useFileDrop, type DroppedFile } from "@/hooks/useFileDrop";
 import { Sidebar } from "./Sidebar";
@@ -34,6 +35,7 @@ export function Layout({ children }: LayoutProps) {
   const closeAll = useOpenFiles((s) => s.closeAll);
   const addFiles = useOpenFiles((s) => s.addFiles);
   const overwriteFiles = useOpenFiles((s) => s.overwriteFiles);
+  const requestScrollToTop = useEditorInstance((s) => s.requestScrollToTop);
   const centered = useEditorPrefs((s) => s.centered);
   const toggleCentered = useEditorPrefs((s) => s.toggleCentered);
   const [feedback, setFeedback] = useState<Feedback>(null);
@@ -117,6 +119,7 @@ export function Layout({ children }: LayoutProps) {
 
   const confirmOverwrite = () => {
     overwriteFiles(pendingConflicts);
+    requestScrollToTop();
     setPendingConflicts([]);
   };
   const cancelOverwrite = () => setPendingConflicts([]);

--- a/src/components/tiptap/TiptapEditor.tsx
+++ b/src/components/tiptap/TiptapEditor.tsx
@@ -32,6 +32,8 @@ function getEditorMarkdown(editor: { storage: unknown }): string {
 export function TiptapEditor() {
   const centered = useEditorPrefs((s) => s.centered);
   const activeId = useOpenFiles((s) => s.activeId);
+  const scrollToTopToken = useEditorInstance((s) => s.scrollToTopToken);
+  const containerRef = useRef<HTMLDivElement>(null);
   const activeReloadToken = useOpenFiles((s) => {
     const file = s.files.find((f) => f.id === s.activeId);
     return file ? file.reloadToken : 0;
@@ -98,8 +100,16 @@ export function TiptapEditor() {
     }
   }, [editor, activeId, activeReloadToken]);
 
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => {
+      containerRef.current?.scrollTo({ top: 0 });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [scrollToTopToken]);
+
   return (
     <Box
+      ref={containerRef}
       className={centered ? "editor-centered" : undefined}
       sx={{
         height: "100%",

--- a/src/hooks/useEditorInstance.test.ts
+++ b/src/hooks/useEditorInstance.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useEditorInstance } from "./useEditorInstance";
+
+describe("useEditorInstance", () => {
+  beforeEach(() => {
+    useEditorInstance.setState({ editor: null, scrollToTopToken: 0 });
+  });
+
+  it("starts with scrollToTopToken of 0", () => {
+    expect(useEditorInstance.getState().scrollToTopToken).toBe(0);
+  });
+
+  it("requestScrollToTop increments scrollToTopToken", () => {
+    useEditorInstance.getState().requestScrollToTop();
+    expect(useEditorInstance.getState().scrollToTopToken).toBe(1);
+
+    useEditorInstance.getState().requestScrollToTop();
+    expect(useEditorInstance.getState().scrollToTopToken).toBe(2);
+  });
+});

--- a/src/hooks/useEditorInstance.ts
+++ b/src/hooks/useEditorInstance.ts
@@ -4,9 +4,13 @@ import { create } from "zustand";
 interface EditorInstanceState {
   editor: Editor | null;
   setEditor: (editor: Editor | null) => void;
+  scrollToTopToken: number;
+  requestScrollToTop: () => void;
 }
 
 export const useEditorInstance = create<EditorInstanceState>((set) => ({
   editor: null,
   setEditor: (editor) => set({ editor }),
+  scrollToTopToken: 0,
+  requestScrollToTop: () => set((state) => ({ scrollToTopToken: state.scrollToTopToken + 1 })),
 }));

--- a/src/hooks/useEditorInstance.ts
+++ b/src/hooks/useEditorInstance.ts
@@ -12,5 +12,6 @@ export const useEditorInstance = create<EditorInstanceState>((set) => ({
   editor: null,
   setEditor: (editor) => set({ editor }),
   scrollToTopToken: 0,
-  requestScrollToTop: () => set((state) => ({ scrollToTopToken: state.scrollToTopToken + 1 })),
+  requestScrollToTop: () =>
+    set((state) => ({ scrollToTopToken: state.scrollToTopToken + 1 })),
 }));

--- a/src/hooks/useOpenFiles.test.ts
+++ b/src/hooks/useOpenFiles.test.ts
@@ -117,6 +117,32 @@ describe("useOpenFiles", () => {
     expect(other.reloadToken).toBe(0);
   });
 
+  it("overwriteFiles activates the first overwritten file when it was not active", () => {
+    useOpenFiles.getState().addFiles([
+      { name: "a.md", markdown: "# A" },
+      { name: "b.md", markdown: "# B" },
+    ]);
+    const [a, b] = useOpenFiles.getState().files;
+    useOpenFiles.getState().setActive(a.id);
+
+    useOpenFiles.getState().overwriteFiles([{ name: "b.md", markdown: "# B reloaded" }]);
+
+    expect(useOpenFiles.getState().activeId).toBe(b.id);
+  });
+
+  it("overwriteFiles keeps the active id when the already-active file is overwritten", () => {
+    useOpenFiles.getState().addFiles([
+      { name: "a.md", markdown: "# A" },
+      { name: "b.md", markdown: "# B" },
+    ]);
+    const [a] = useOpenFiles.getState().files;
+    useOpenFiles.getState().setActive(a.id);
+
+    useOpenFiles.getState().overwriteFiles([{ name: "a.md", markdown: "# A reloaded" }]);
+
+    expect(useOpenFiles.getState().activeId).toBe(a.id);
+  });
+
   it("overwriteFiles ignores names not present in the store", () => {
     useOpenFiles.getState().addFiles([{ name: "a.md", markdown: "# A" }]);
     useOpenFiles.getState().overwriteFiles([{ name: "missing.md", markdown: "# X" }]);

--- a/src/hooks/useOpenFiles.test.ts
+++ b/src/hooks/useOpenFiles.test.ts
@@ -24,11 +24,11 @@ describe("useOpenFiles", () => {
     expect(state.activeId).toBe(state.files[0].id);
   });
 
-  it("keeps existing active id when adding more files", () => {
+  it("activates the first newly added file when adding more files", () => {
     useOpenFiles.getState().addFiles([{ name: "a.md", markdown: "# A" }]);
-    const first = useOpenFiles.getState().activeId;
     useOpenFiles.getState().addFiles([{ name: "b.md", markdown: "# B" }]);
-    expect(useOpenFiles.getState().activeId).toBe(first);
+    const bId = useOpenFiles.getState().files.find((f) => f.name === "b.md")!.id;
+    expect(useOpenFiles.getState().activeId).toBe(bId);
   });
 
   it("marks active file dirty on content change", () => {

--- a/src/hooks/useOpenFiles.ts
+++ b/src/hooks/useOpenFiles.ts
@@ -116,7 +116,8 @@ export const useOpenFiles = create<OpenFilesState>()(
               reloadToken: file.reloadToken + 1,
             };
           });
-          return { files };
+          const firstOverwritten = files.find((f) => byName.has(f.name));
+          return { files, activeId: firstOverwritten ? firstOverwritten.id : state.activeId };
         }),
 
       updateActiveMarkdown: (markdown) =>

--- a/src/hooks/useOpenFiles.ts
+++ b/src/hooks/useOpenFiles.ts
@@ -98,8 +98,7 @@ export const useOpenFiles = create<OpenFilesState>()(
             reloadToken: 0,
           }));
           const files = [...state.files, ...created];
-          const activeId = state.activeId ?? created[0].id;
-          return { files, activeId };
+          return { files, activeId: created[0].id };
         }),
 
       overwriteFiles: (incoming) =>

--- a/src/hooks/useOpenFiles.ts
+++ b/src/hooks/useOpenFiles.ts
@@ -117,7 +117,10 @@ export const useOpenFiles = create<OpenFilesState>()(
             };
           });
           const firstOverwritten = files.find((f) => byName.has(f.name));
-          return { files, activeId: firstOverwritten ? firstOverwritten.id : state.activeId };
+          return {
+            files,
+            activeId: firstOverwritten ? firstOverwritten.id : state.activeId,
+          };
         }),
 
       updateActiveMarkdown: (markdown) =>


### PR DESCRIPTION
## Summary

- `useOpenFiles.overwriteFiles` を修正し、上書き後に最初の上書きファイルを自動でアクティブ（選択状態）にする
- `useEditorInstance` に `scrollToTopToken` / `requestScrollToTop` を追加し、エディタスクロールを外部から制御できるようにする
- `TiptapEditor` に `containerRef` を追加し、`scrollToTopToken` の変化を検知してエディタコンテナを冒頭にスクロール
- `Layout.confirmOverwrite` で上書き確定後に `requestScrollToTop()` を呼ぶ

## 動作詳細

| 状況 | 期待動作 |
|---|---|
| 同名ファイル上書き確認後 | 上書き → そのファイルを選択 → 冒頭スクロール |
| 既にアクティブなファイルを再アップロード | 選択状態維持 → 冒頭スクロール |
| キャンセル | 変更なし |
| 別名ファイル | 既存の挙動に影響しない |

## Test plan

- [x] `useEditorInstance.test.ts` 新規追加 — `scrollToTopToken` の初期値と `requestScrollToTop` のインクリメントを確認
- [x] `useOpenFiles.test.ts` 追加 — `overwriteFiles` が非アクティブファイルを上書き後にアクティブにすること / 既アクティブファイルの場合も activeId が保持されることを確認
- [x] `Layout.test.tsx` 追加 — 競合ダイアログの表示 / 上書き確定時の activeId 変更 / scrollToTopToken インクリメント / キャンセル時の変更なし を確認
- [x] 全 33 テスト PASS

Closes #28
